### PR TITLE
feat: add hideEmail transformer for PII masking

### DIFF
--- a/src/Instances/StringMorpherInstance.php
+++ b/src/Instances/StringMorpherInstance.php
@@ -52,6 +52,7 @@ use Stringable;
  * @method StringMorpherInstance maskBrCnpj()
  * @method StringMorpherInstance maskBrPhone()
  * @method StringMorpherInstance maskBrReal()
+ * @method StringMorpherInstance hideEmail()
  */
 class StringMorpherInstance implements Stringable, JsonSerializable
 {

--- a/src/StringMorpher.php
+++ b/src/StringMorpher.php
@@ -44,6 +44,7 @@ use SSolWEB\StringMorpher\Instances\StringMorpherInstance;
  * @method static StringMorpherInstance maskBrCnpj(string $input)
  * @method static StringMorpherInstance maskBrPhone(string $input)
  * @method static StringMorpherInstance maskBrReal(string $input)
+ * @method static StringMorpherInstance hideEmail(string $input)
  */
 class StringMorpher
 {

--- a/src/Transformers/HideEmailTransformer.php
+++ b/src/Transformers/HideEmailTransformer.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SSolWEB\StringMorpher\Transformers;
+
+use SSolWEB\StringMorpher\Contracts\StringTransformerInterface;
+
+/**
+ * Transformer that masks parts of an email address for privacy / compliance
+ * (LGPD, GDPR). Keeps the first two characters of the local part and the
+ * first two characters of the domain name; the TLD is preserved.
+ *
+ * Examples:
+ *   joao.silva@example.com   -> jo********@ex*****.com
+ *   j@x.io                   -> j@x*.io
+ *   not-an-email             -> not-an-email  (returned unchanged)
+ *
+ * @package SSolWEB\StringMorpher\Transformers
+ */
+final class HideEmailTransformer implements StringTransformerInterface
+{
+    /**
+     * Apply email masking.
+     *
+     * @param string $input The string to transform.
+     * @param mixed ...$args Not used.
+     * @return string The masked email, or the input unchanged if it doesn't
+     *                parse as an email.
+     */
+    public function transform(string $input, mixed ...$args): string
+    {
+        if (!filter_var($input, FILTER_VALIDATE_EMAIL)) {
+            return $input;
+        }
+
+        $atPos = strrpos($input, '@');
+        if ($atPos === false) {
+            return $input;
+        }
+
+        $local = substr($input, 0, $atPos);
+        $domain = substr($input, $atPos + 1);
+
+        // Split on the FIRST dot so compound suffixes like `.co.uk` are
+        // preserved in full. For `contoso.co.uk` this yields host="contoso"
+        // and tld=".co.uk".
+        $dotPos = strpos($domain, '.');
+        if ($dotPos === false) {
+            return $input;
+        }
+
+        $host = substr($domain, 0, $dotPos);
+        $tld = substr($domain, $dotPos);
+
+        return $this->mask($local) . '@' . $this->mask($host) . $tld;
+    }
+
+    /**
+     * Mask a segment: keep the first two characters, replace the rest with `*`.
+     * Shorter segments keep whatever prefix they have and add one star so the
+     * mask is always visible.
+     */
+    private function mask(string $segment): string
+    {
+        $len = strlen($segment);
+        if ($len <= 2) {
+            return $segment . '*';
+        }
+        return substr($segment, 0, 2) . str_repeat('*', $len - 2);
+    }
+}

--- a/tests/Transformers/HideEmailTransformerTest.php
+++ b/tests/Transformers/HideEmailTransformerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SSolWEB\StringMorpher\Tests\Transformers;
+
+use PHPUnit\Framework\TestCase;
+use SSolWEB\StringMorpher\Transformers\HideEmailTransformer;
+use SSolWEB\StringMorpher\StringMorpher as SM;
+use SSolWEB\StringMorpher\Instances\StringMorpherInstance;
+
+class HideEmailTransformerTest extends TestCase
+{
+    public function testTransform()
+    {
+        $transformer = new HideEmailTransformer();
+
+        $tests = [
+            'jo********@ex*****.com' => 'joao.silva@example.com',
+            'jo***@gm***.com'        => 'joana@gmail.com',
+            'al***@co*****.co.uk'    => 'alice@contoso.co.uk',
+        ];
+
+        foreach ($tests as $expected => $input) {
+            $this->assertEquals($expected, $transformer->transform($input));
+        }
+    }
+
+    public function testShortLocalOrDomainKeepsOneMaskStar()
+    {
+        $transformer = new HideEmailTransformer();
+
+        $this->assertEquals('a*@x*.io', $transformer->transform('a@x.io'));
+        $this->assertEquals('bo*@x*.io', $transformer->transform('bo@x.io'));
+        $this->assertEquals('al***@x*.io', $transformer->transform('alice@x.io'));
+    }
+
+    public function testInvalidEmailIsReturnedUnchanged()
+    {
+        $transformer = new HideEmailTransformer();
+
+        $this->assertEquals('not-an-email', $transformer->transform('not-an-email'));
+        $this->assertEquals('', $transformer->transform(''));
+        $this->assertEquals('@no-local.com', $transformer->transform('@no-local.com'));
+    }
+
+    public function testFacade()
+    {
+        $tests = [
+            'jo********@ex*****.com' => ['joao.silva@example.com'],
+            'al***@co*****.co.uk'    => ['alice@contoso.co.uk'],
+            'not-an-email'           => ['not-an-email'],
+        ];
+
+        foreach ($tests as $expected => $params) {
+            $actual = SM::hideEmail(...$params);
+            $this->assertEquals($expected, $actual);
+            $this->assertInstanceOf(StringMorpherInstance::class, $actual);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds `hideEmail` - a new transformer that masks an email address for privacy / compliance logging (LGPD / GDPR), matching the existing Brazilian-format `maskBrCpf` / `maskBrPhone` / etc. helpers.

## Why this matters
Issue #25 laid out the use case (audit logs, "reset link sent to j\*\*\*@gm\*\*\*.com", customer-support dashboards) and the existing workaround - every caller manually `explode('@', $email)` + `substr()`, which drifts in style and edge-case handling. One reusable transformer removes that surface.

## Changes
- `src/Transformers/HideEmailTransformer.php`: new final class implementing `StringTransformerInterface`.
  - `filter_var(..., FILTER_VALIDATE_EMAIL)` short-circuits: invalid input returns unchanged (matches how `MaskBrCpf` returns early when digits don't match).
  - Splits the domain on the **first** dot so compound suffixes survive (`contoso.co.uk` -> `co*****.co.uk`, not the `.uk`-only result `strrpos` would give).
  - `mask()` keeps the first two characters and pads the rest with `*`. Segments of length ≤ 2 keep their prefix plus one `*` so the mask stays visible for short addresses like `a@x.io`.
- `src/StringMorpher.php` and `src/Instances/StringMorpherInstance.php`: add the `@method hideEmail(...)` hints alongside the existing mask helpers, so IDE autocomplete and static analysis pick it up.
- `tests/Transformers/HideEmailTransformerTest.php`: mirror the `MaskBrCpfTransformerTest` shape - direct `transform()` cases, short-segment behaviour, invalid-input passthrough, and the `SM::hideEmail` facade.

## Testing
```
$ vendor/bin/phpunit tests/Transformers/HideEmailTransformerTest.php
OK (4 tests, 15 assertions)

$ vendor/bin/phpunit
OK (120 tests, 756 assertions)
```

All existing tests still pass. The new transformer is registered through the library's dynamic `__call` loader - no changes to `StringMorpherInstance::__call` were needed.

## Examples
```php
use SSolWEB\StringMorpher\StringMorpher as SM;

SM::hideEmail('joao.silva@example.com'); // jo********@ex*****.com
SM::hideEmail('alice@contoso.co.uk');    // al***@co*****.co.uk
SM::hideEmail('a@x.io');                 // a*@x*.io
SM::hideEmail('not-an-email');           // not-an-email
```

Fixes #25

This contribution was developed with AI assistance (Claude Code).
