### PR TITLE
feat(transformers): add EscapeHtml for safe HTML output

### DIFF
--- a/docs/docs/methods/escape-html.md
+++ b/docs/docs/methods/escape-html.md
@@ -1,0 +1,45 @@
+---
+title: "escapeHtml"
+parent: Methods
+nav_order:
+---
+
+# escapeHtml
+
+Escapes HTML special characters to their corresponding entities to prevent HTML injection while preserving UTF-8.
+
+## Behavior
+- Converts `<`, `>`, `&`, `\"`, `'` and other special characters to HTML entities.
+- Uses `ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE` with `UTF-8` to avoid corrupting multibyte text and to substitute invalid bytes.
+- Escapes quotes for attribute contexts; suitable for both element content and attribute values.
+- Multibyte-safe and suitable for HTML contexts.
+
+## Usage
+
+```php
+echo SM::escapeHtml('<script>alert("XSS")</script>');
+// &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;
+
+echo SM::make('  <b>hello</b>  ')
+    ->trim()
+    ->escapeHtml();
+// &lt;b&gt;hello&lt;/b&gt;
+```
+
+## Examples
+
+```php
+$title = 'Click "here" & learn';
+echo (string)SM::escapeHtml($title);
+// Click &quot;here&quot; &amp; learn
+
+echo SM::escapeHtml(null);
+// '' (empty string)
+
+echo SM::escapeHtml('Café Münster <em>x</em>');
+// Café Münster &lt;em&gt;x&lt;/em&gt;
+```
+
+## Technical notes
+- Implementation uses `htmlspecialchars($input, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, 'UTF-8')`.
+- Designed to preserve UTF-8 text and avoid breaking accented characters.

--- a/src/Instances/StringMorpherInstance.php
+++ b/src/Instances/StringMorpherInstance.php
@@ -18,6 +18,7 @@ use Stringable;
  * @method StringMorpherInstance append(string $append)
  * @method StringMorpherInstance capitalize()
  * @method StringMorpherInstance encodeUrl()
+ * @method StringMorpherInstance escapeHtml()
  * @method StringMorpherInstance fromBase64()
  * @method StringMorpherInstance limit(int $length, string|null $end = null)
  * @method StringMorpherInstance normalize()

--- a/src/StringMorpher.php
+++ b/src/StringMorpher.php
@@ -10,6 +10,7 @@ use SSolWEB\StringMorpher\Instances\StringMorpherInstance;
  * @method static StringMorpherInstance append(string $input, string $append)
  * @method static StringMorpherInstance capitalize(string $input)
  * @method static StringMorpherInstance encodeUrl(string $input)
+ * @method static StringMorpherInstance escapeHtml(string $input)
  * @method static StringMorpherInstance fromBase64(string $input)
  * @method static StringMorpherInstance limit(string $input, int $length, string $end = null)
  * @method static StringMorpherInstance normalize(string $input)

--- a/src/Transformers/EscapeHtmlTransformer.php
+++ b/src/Transformers/EscapeHtmlTransformer.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SSolWEB\StringMorpher\Transformers;
+
+use SSolWEB\StringMorpher\Contracts\StringTransformerInterface;
+
+/**
+ * Transformer for escaping special HTML characters to their entity equivalents.
+ *
+ * @package SSolWEB\StringMorpher\Transformers
+ */
+final class EscapeHtmlTransformer implements StringTransformerInterface
+{
+    /**
+     * Convert special characters to HTML entities for safe HTML output.
+     *
+     * @param string $input The string to transform.
+     * @param mixed ...$args Not used.
+     * @return string The HTML-escaped string.
+     */
+    public function transform(string $input, mixed ...$args): string
+    {
+        return htmlspecialchars($input, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, 'UTF-8');
+    }
+}

--- a/tests/Transformers/EscapeHtmlTransformerTest.php
+++ b/tests/Transformers/EscapeHtmlTransformerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SSolWEB\StringMorpher\Tests\Transformers;
+
+use PHPUnit\Framework\TestCase;
+use SSolWEB\StringMorpher\Instances\StringMorpherInstance;
+use SSolWEB\StringMorpher\StringMorpher as SM;
+use SSolWEB\StringMorpher\Transformers\EscapeHtmlTransformer;
+
+class EscapeHtmlTransformerTest extends TestCase
+{
+    public static function paramProvider(): array
+    {
+        return [
+            ['&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;', '<script>alert("XSS")</script>'],
+            ['5 &lt; 7 &amp; &quot;hello&quot;', '5 < 7 & "hello"'],
+            ['Click &quot;here&quot; &amp; learn', 'Click "here" & learn'],
+            ['', ''],
+            ['plain text', 'plain text'],
+            ['Caf&amp;eacute;', 'Caf&eacute;'],
+            ['It&apos;s a test', "It's a test"],
+        ];
+    }
+
+    public function testTransform()
+    {
+        $transformer = new EscapeHtmlTransformer();
+
+        foreach ($this->paramProvider() as $args) {
+            $expected = array_shift($args);
+            $result = $transformer->transform(...$args);
+            $this->assertEquals($expected, $result);
+        }
+    }
+
+    public function testFacade()
+    {
+        foreach ($this->paramProvider() as $args) {
+            $expected = array_shift($args);
+            $result = SM::escapeHtml(...$args);
+            $this->assertEquals($expected, $result);
+            $this->assertInstanceOf(StringMorpherInstance::class, $result);
+        }
+    }
+
+    public function testFacadeAcceptsNull()
+    {
+        $result = SM::escapeHtml(null);
+        $this->assertEquals('', $result);
+        $this->assertInstanceOf(StringMorpherInstance::class, $result);
+    }
+
+    public function testFluent()
+    {
+        $actual = SM::make('  <b>hello</b>  ')
+            ->trim()
+            ->escapeHtml();
+
+        $this->assertEquals('&lt;b&gt;hello&lt;/b&gt;', $actual);
+        $this->assertInstanceOf(StringMorpherInstance::class, $actual);
+    }
+
+    public function testEscapesAttributeQuotesForAttributeContext()
+    {
+        $title = 'Click "here" & learn';
+        $escaped = SM::escapeHtml($title);
+        $this->assertEquals('Click &quot;here&quot; &amp; learn', (string)$escaped);
+    }
+
+    public function testHandlesUtf8WithoutCorrupting()
+    {
+        $input = 'Café Münster <em>x</em>';
+        $expected = 'Café Münster &lt;em&gt;x&lt;/em&gt;';
+        $this->assertEquals($expected, (string)SM::escapeHtml($input));
+    }
+}


### PR DESCRIPTION
## What

Adds an EscapeHtml transformer that wraps htmlspecialchars to convert special HTML characters to their entity equivalents:

- `<` and `>` (element-content escaping)
- `&` (entity prefix)
- `\"` and `'` (attribute-value contexts)

Implementation uses `htmlspecialchars(\$input, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, 'UTF-8')`. ENT_HTML5 produces `&apos;` for single quotes (HTML5 standard); ENT_SUBSTITUTE replaces invalid UTF-8 sequences with U+FFFD instead of returning an empty string.

## Why

Issue #26 requested this for XSS prevention when displaying user-generated content in HTML contexts. Complements the existing `stripTags` (removes HTML) by preserving content while making it safe for display.

## API

Static and fluent both work, picked up automatically by the Instance `__call` dispatcher:

```php
SM::escapeHtml('<script>alert(\"XSS\")</script>');
// => '&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;'

SM::make(\$userInput)->trim()->escapeHtml();
```

## Test plan

- [x] `phpunit tests/Transformers/EscapeHtmlTransformerTest.php`: 6 tests, 27 assertions, all pass
- [x] Full suite: 141 tests, 829 assertions, all pass
- [x] PHPDoc `@method` lines added to both `StringMorpher` and `StringMorpherInstance` for IDE autocomplete

## Notes

- Default behavior follows PHP htmlspecialchars: double-encoding is ON (re-escaping `&eacute;` produces `&amp;eacute;`). The issue lists \"idempotent if possible\" as a soft requirement; defaulting to safe-by-double-encode is the standard PHP convention and matches the mental model that escapeHtml input is raw user data.
- ENT_HTML5 outputs `&apos;` rather than `&#039;` for the single-quote case the issue lists. Both are valid HTML5; `&apos;` is what the constant produces.

Closes #26