### PR TITLE
feat: add remove transformer for substring removal

### DIFF
--- a/docs/docs/methods/remove.md
+++ b/docs/docs/methods/remove.md
@@ -1,0 +1,31 @@
+---
+title: "remove"
+parent: Methods
+nav_order:
+---
+
+# remove
+
+This method removes all occurrences of a search string or strings from a string. It supports both case-sensitive and case-insensitive removal.
+
+## Usage
+
+```php
+$string = 'test string';
+$string = SM::remove($string, 'st');
+// or
+$string = SM::make($string)
+    ->remove('st');
+echo $string; // te ring
+```
+
+### Case-insensitive removal parameter
+
+```php
+$string = 'Hello HELLO';
+$string = SM::remove($string, 'hello', false);
+// or
+$string = SM::make($string)
+    ->remove('hello', false);
+var_export($string); // ' '
+```

--- a/src/Instances/StringMorpherInstance.php
+++ b/src/Instances/StringMorpherInstance.php
@@ -26,6 +26,7 @@ use Stringable;
  * @method StringMorpherInstance onlyNumbers()
  * @method StringMorpherInstance padL(int $length, string $padChar = ' ')
  * @method StringMorpherInstance padR(int $length, string $padChar = ' ')
+ * @method StringMorpherInstance remove(array|string $needle, bool $caseSensitive = true)
  * @method StringMorpherInstance replace(array|string $needle, array|string $replace, bool $caseSensitive = true)
  * @method StringMorpherInstance replaceRegex(array|string $needleRegex, array|string $replace)
  * @method StringMorpherInstance reverse()

--- a/src/StringMorpher.php
+++ b/src/StringMorpher.php
@@ -18,6 +18,7 @@ use SSolWEB\StringMorpher\Instances\StringMorpherInstance;
  * @method static StringMorpherInstance onlyNumbers(string $input)
  * @method static StringMorpherInstance padL(string $input, int $length, string $padChar = ' ')
  * @method static StringMorpherInstance padR(string $input, int $length, string $padChar = ' ')
+ * @method static StringMorpherInstance remove(string $input, array|string $needle, bool $cs = true)
  * @method static StringMorpherInstance replace(string $input, array|string $needle, array|string $replace, bool $cs)
  * @method static StringMorpherInstance replaceRegex(string $input, array|string $needleRegex, array|string $replace)
  * @method static StringMorpherInstance reverse(string $input)

--- a/src/Transformers/RemoveTransformer.php
+++ b/src/Transformers/RemoveTransformer.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SSolWEB\StringMorpher\Transformers;
+
+use SSolWEB\StringMorpher\Contracts\StringTransformerInterface;
+
+/**
+ * Transformer for removing substrings from a string.
+ *
+ * @package SSolWEB\StringMorpher\Transformers
+ */
+final class RemoveTransformer implements StringTransformerInterface
+{
+    /**
+     * Remove all occurrences of a string.
+     *
+     * @param string $input The string to transform.
+     * @param mixed ...$args Arguments: [0] => array|string $needle, [1] => bool $caseSensitive.
+     * @return string The string with removals.
+     */
+    public function transform(string $input, mixed ...$args): string
+    {
+        $needle = $args[0];
+        $caseSensitive = $args[1] ?? true;
+
+        return $caseSensitive
+            ? str_replace($needle, '', $input)
+            : str_ireplace($needle, '', $input);
+    }
+}

--- a/tests/Transformers/RemoveTransformerTest.php
+++ b/tests/Transformers/RemoveTransformerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SSolWEB\StringMorpher\Tests\Transformers;
+
+use PHPUnit\Framework\TestCase;
+use SSolWEB\StringMorpher\Transformers\RemoveTransformer;
+use SSolWEB\StringMorpher\StringMorpher as SM;
+use SSolWEB\StringMorpher\Instances\StringMorpherInstance;
+
+class RemoveTransformerTest extends TestCase
+{
+    public function testTransformCaseSensitive()
+    {
+        $transformer = new RemoveTransformer();
+
+        $tests = [
+            'te ring' => ['test string', 'st'],
+            'The quick brown jumps' => ['The quick brown fox jumps', 'fox '],
+            'green' => ['red green blue', ['red ', ' blue']],
+            'test string' => ['test string', 'St'],
+        ];
+
+        foreach ($tests as $expected => $test) {
+            $actual = $transformer->transform(...$test);
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
+    public function testTransformCaseInsensitive()
+    {
+        $transformer = new RemoveTransformer();
+
+        $tests = [
+            ' ' => ['Hello HELLO', 'hello', false],
+            'The quick brown jumps' => ['The quick brown FOX jumps', 'fox ', false],
+            'green' => ['RED green BLUE', ['red ', ' blue'], false],
+        ];
+
+        foreach ($tests as $expected => $test) {
+            $actual = $transformer->transform(...$test);
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
+    public function testFacade()
+    {
+        // Case sensitive
+        $tests = [
+            'te ring' => ['test string', 'st'],
+            'The quick brown jumps' => ['The quick brown fox jumps', 'fox '],
+            'green' => ['red green blue', ['red ', ' blue']],
+            'test string' => ['test string', 'St'],
+        ];
+
+        foreach ($tests as $expected => $params) {
+            $actual = SM::remove(...$params);
+            $this->assertEquals($expected, $actual);
+            $this->assertInstanceOf(StringMorpherInstance::class, $actual);
+        }
+
+        // Case insensitive
+        $tests = [
+            ' ' => ['Hello HELLO', 'hello', false],
+            'The quick brown jumps' => ['The quick brown FOX jumps', 'fox ', false],
+            'green' => ['RED green BLUE', ['red ', ' blue'], false],
+        ];
+
+        foreach ($tests as $expected => $params) {
+            $actual = SM::remove(...$params);
+            $this->assertEquals($expected, $actual);
+            $this->assertInstanceOf(StringMorpherInstance::class, $actual);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 Description

Adds a `remove` transformer that strips one or more substrings from a string. It accepts a string or an array of needles and an optional case-sensitivity flag (default true), delegating to `str_replace` / `str_ireplace` with an empty replacement.

Closes #48

## Why this matters

Removing substrings is currently expressed as `replace($needle, '')`, which hides the intent behind a replacement with an empty argument. The issue asks for a dedicated, intention-revealing operation for the common case of cleaning text (dropping target words, punctuation, or whitespace before storing or displaying). `remove` makes those pipelines read clearly while reusing the exact, well-tested semantics of `replace`, so it stays squarely within the library's string-transformation scope.

## 🎯 Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Enhancement (improvement of existing feature)
- [ ] 📝 Chore (documentation, refactoring, etc)

## ✅ Implementation Checklist

### Code
- [x] Transformer created in `src/Transformers/` implementing `StringTransformerInterface`
- [x] PHPDoc `@method` added in `src/StringMorpher.php`
- [x] PHPDoc `@method` added in `src/Instances/StringMorpherInstance.php`

### Tests
- [x] Tests created in `tests/Transformers/`
- [x] Tests cover main use cases
- [x] Tests cover edge cases (array of needles, case-insensitive, no-match)
- [x] All tests pass (`vendor/bin/phpunit`)

### Quality
- [x] Code passes linter (`vendor/bin/phpcs`)
- [x] Code follows project standards

### Documentation
- [x] Method documented in `docs/docs/methods/`
- [x] Usage examples included (static and fluent)
- [x] Parameters and return values documented

## 📸 Screenshots (if applicable)

Not applicable (no visual changes). Verification: full suite 144 tests / 850 assertions pass; `phpcs` clean on all changed files.
