### PR TITLE
feat: add unwrap transformer for prefix/suffix removal

### DIFF
--- a/docs/docs/methods/unwrap.md
+++ b/docs/docs/methods/unwrap.md
@@ -1,0 +1,35 @@
+---
+title: unwrap
+parent: Methods
+nav_order:
+---
+
+# unwrap
+
+Removes a matching prefix and suffix from a string.
+
+## Usage
+
+```php
+$string = '(abc)';
+$string = SM::unwrap($string, '(', ')');
+// or
+$string = SM::make($string)
+    ->unwrap('(', ')');
+
+echo $string; // abc
+```
+
+## Wrap omitting suffix
+
+If the suffix is not provided, it defaults to the same value as the prefix.
+
+```php
+$string = '"abc"';
+$string = SM::unwrap($string, '"');
+// or
+$string = SM::make($string)
+    ->unwrap('"');
+
+echo $string; // abc
+```

--- a/src/Instances/StringMorpherInstance.php
+++ b/src/Instances/StringMorpherInstance.php
@@ -50,6 +50,7 @@ use Stringable;
  * @method StringMorpherInstance toDotCase()
  * @method StringMorpherInstance toFlatCase()
  * @method StringMorpherInstance wrap(string|null $prefix, string|null $suffix = null)
+ * @method StringMorpherInstance unwrap(string|null $prefix, string|null $suffix = null)
  * @method StringMorpherInstance mask(string $maskPattern, array $customMap = [])
  * @method StringMorpherInstance maskBrCep()
  * @method StringMorpherInstance maskBrCpf()

--- a/src/StringMorpher.php
+++ b/src/StringMorpher.php
@@ -42,6 +42,7 @@ use SSolWEB\StringMorpher\Instances\StringMorpherInstance;
  * @method static StringMorpherInstance toDotCase(string $input)
  * @method static StringMorpherInstance toFlatCase(string $input)
  * @method static StringMorpherInstance wrap(string $input, string|null $prefix, string|null $suffix = null)
+ * @method static StringMorpherInstance unwrap(string $input, string|null $prefix, string|null $suffix = null)
  * @method static StringMorpherInstance mask(string $input, string $maskPattern, array $customMap = [])
  * @method static StringMorpherInstance maskBrCep(string $input)
  * @method static StringMorpherInstance maskBrCpf(string $input)

--- a/src/Transformers/UnwrapTransformer.php
+++ b/src/Transformers/UnwrapTransformer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SSolWEB\StringMorpher\Transformers;
+
+use SSolWEB\StringMorpher\Contracts\StringTransformerInterface;
+
+/**
+ * Transformer for removing a prefix/suffix pair from a string.
+ */
+final class UnwrapTransformer implements StringTransformerInterface
+{
+    /**
+     * Removes a matching prefix and suffix from input.
+     *
+     * If suffix is not provided, it defaults to prefix.
+     *
+     * @param string $input The string to transform.
+     * @param mixed ...$args Arguments: [0] => string|null $prefix, [1] => string|null $suffix.
+     * @return string The unwrapped string.
+     */
+    public function transform(string $input, mixed ...$args): string
+    {
+        $prefix = (string)($args[0] ?? '');
+        $suffix = array_key_exists(1, $args) ? (string)($args[1] ?? '') : $prefix;
+
+        if ($prefix !== '' && str_starts_with($input, $prefix)) {
+            $input = substr($input, strlen($prefix));
+        }
+
+        if ($suffix !== '' && str_ends_with($input, $suffix)) {
+            $input = substr($input, 0, strlen($input) - strlen($suffix));
+        }
+
+        return $input;
+    }
+}

--- a/tests/Transformers/UnwrapTransformerTest.php
+++ b/tests/Transformers/UnwrapTransformerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SSolWEB\StringMorpher\Tests\Transformers;
+
+use PHPUnit\Framework\TestCase;
+use SSolWEB\StringMorpher\Instances\StringMorpherInstance;
+use SSolWEB\StringMorpher\StringMorpher as SM;
+use SSolWEB\StringMorpher\Transformers\UnwrapTransformer;
+
+class UnwrapTransformerTest extends TestCase
+{
+    public function testTransform()
+    {
+        $transformer = new UnwrapTransformer();
+
+        $tests = [
+            ['abc', '(abc)', '(', ')'],
+            ['bcd', '"bcd"', '"'],
+            ['', '[]', '[', ']'],
+            ['cde', 'cde', '', ''],
+            ['def', '<def>', '<', '>'],
+            ['efh', 'efh', null, null],
+            ['fhi', '(fhi]', '(', ']'],
+        ];
+
+        foreach ($tests as $test) {
+            $expected = array_shift($test);
+            $input = array_shift($test);
+            $actual = $transformer->transform($input, ...$test);
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
+    public function testFacade()
+    {
+        $tests = [
+            ['abc', ['(abc)', '(', ')']],
+            ['bcd', ['"bcd"', '"']],
+            ['cde', ['[cde]', '[', ']']],
+            ['def', ['def', '', '']],
+            ['efh', ['(efh]', '(', ']']],
+            ['fhi', ['123fhi123', 123]],
+            ['ghi', ['ghi', null]],
+            ['', ['[]', '[', ']']],
+            ['123', ['123', null, null]],
+        ];
+
+        foreach ($tests as [$expected, $params]) {
+            $actual = SM::unwrap(...$params);
+            $this->assertEquals($expected, $actual);
+            $this->assertInstanceOf(StringMorpherInstance::class, $actual);
+        }
+    }
+}


### PR DESCRIPTION
added corresponding documentation

Refs: #47

## 📝 Description

Add a transformer unwrap that removes a specified prefix and/or suffix. Suffix param should default to prefix if not given. Example: unwrap('(abc)', '(', ')') => 'abc'. Example²: unwrap('"abc"', '"') => 'abc'. This makes it possible to clean enclosures in a single step instead of manual substr or regex.

Closes #47

## 🎯 Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Enhancement (improvement of existing feature)
- [ ] 📝 Chore (documentation, refactoring, etc)

## ✅ Implementation Checklist

### Code
- [x] Transformer created in `src/Transformers/` implementing `StringTransformerInterface`
- [x] PHPDoc `@method` added in `src/StringMorpher.php`
- [x] PHPDoc `@method` added in `src/Instances/StringMorpherInstance.php`

### Tests
- [x] Tests created in `tests/Transformers/`
- [x] Tests cover main use cases
- [x] Tests cover edge cases (null, empty string, etc)
- [x] All tests pass (`vendor/bin/phpunit`)

### Quality
- [x] Code passes linter (`vendor/bin/phpcs`)
- [x] Code follows project standards

### Documentation
- [x] Method documented in `docs/docs/methods/`
- [x] Usage examples included (static and fluent)
- [x] Parameters and return values documented

